### PR TITLE
Added dotnet standard 1.3 as a Target Framework

### DIFF
--- a/src/MediatR.Extensions.Autofac.DependencyInjection/MediatR.Extensions.Autofac.DependencyInjection.csproj
+++ b/src/MediatR.Extensions.Autofac.DependencyInjection/MediatR.Extensions.Autofac.DependencyInjection.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <TargetFramework>netstandard1.3</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard1.3</TargetFrameworks>
     <LangVersion>7.2</LangVersion>
     <Version>2.0.1</Version>
     <FileVersion>2.0.1.0</FileVersion>

--- a/src/MediatR.Extensions.Autofac.DependencyInjection/MediatR.Extensions.Autofac.DependencyInjection.csproj
+++ b/src/MediatR.Extensions.Autofac.DependencyInjection/MediatR.Extensions.Autofac.DependencyInjection.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard1.3</TargetFramework>
     <LangVersion>7.2</LangVersion>
     <Version>2.0.1</Version>
     <FileVersion>2.0.1.0</FileVersion>
@@ -16,6 +17,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Autofac" Version="4.8.1" />
-    <PackageReference Include="MediatR" Version="6.0.0" />
+    <PackageReference Include="MediatR" Version="5.1.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Downgraded MediatR to version 5.2.0 - which supports 1.3