### PR TITLE
fix: Samples registration error ComponentNotRegisteredException

### DIFF
--- a/samples/MediatR.Extensions.Autofac.DepdencyInjection.ConsoleApp/Program.cs
+++ b/samples/MediatR.Extensions.Autofac.DepdencyInjection.ConsoleApp/Program.cs
@@ -26,7 +26,9 @@ public static class Program
 
         var builder = new ContainerBuilder();
 
-        var configuration = MediatRConfigurationBuilder.Create(typeof(CustomerLoadQuery).Assembly).Build();
+        var configuration = MediatRConfigurationBuilder.Create(typeof(CustomerLoadQuery).Assembly)
+            .WithAllOpenGenericHandlerTypesRegistered()
+            .Build();
         builder.RegisterMediatR(configuration);
 
         builder.RegisterType<CustomersRepository>()

--- a/samples/MediatR.Extensions.Autofac.DependencyInjection.WebApi/Startup.cs
+++ b/samples/MediatR.Extensions.Autofac.DependencyInjection.WebApi/Startup.cs
@@ -36,7 +36,9 @@ public class Startup
             .As<ICustomersRepository>()
             .SingleInstance();
 
-        var configuration = MediatRConfigurationBuilder.Create(typeof(CustomerLoadQuery).Assembly).Build();
+        var configuration = MediatRConfigurationBuilder.Create(typeof(CustomerLoadQuery).Assembly)
+            .WithAllOpenGenericHandlerTypesRegistered()
+            .Build();
         
         builder.RegisterMediatR(configuration);
     }


### PR DESCRIPTION
Fix Samples registration error ComponentNotRegisteredException by adding `WithAllOpenGenericHandlerTypesRegistered` to configurationBuilder

Was receiving the error before change:

```c#
Autofac.Core.Registration.ComponentNotRegisteredException: 'The requested service 'MediatR.IRequestHandler`2[[MediatR.Extensions.Autofac.DependencyInjection.Shared.Commands.CustomerAddCommand, MediatR.Extensions.Autofac.DependencyInjection.Shared, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null],[MediatR.Unit, MediatR.Contracts, Version=1.0.1.0, Culture=neutral, PublicKeyToken=bb9a41a5e8aaa7e2]]' has not been registered. To avoid this exception, either register a component to provide the service, check for service registration using IsRegistered(), or use the ResolveOptional() method to resolve an optional dependency.'
```