### PR TITLE
feat: Add support for Mediatr v12

### DIFF
--- a/samples/MediatR.Extensions.Autofac.DepdencyInjection.ConsoleApp/Program.cs
+++ b/samples/MediatR.Extensions.Autofac.DepdencyInjection.ConsoleApp/Program.cs
@@ -26,7 +26,9 @@ public static class Program
 
         var builder = new ContainerBuilder();
 
-        var configuration = MediatRConfigurationBuilder.Create(typeof(CustomerLoadQuery).Assembly).Build();
+        var configuration = MediatRConfigurationBuilder.Create(typeof(CustomerLoadQuery).Assembly)
+            .WithAllOpenGenericHandlerTypesRegistered()
+            .Build();
         builder.RegisterMediatR(configuration);
 
         builder.RegisterType<CustomersRepository>()

--- a/samples/MediatR.Extensions.Autofac.DepdencyInjection.ConsoleApp/Program.cs
+++ b/samples/MediatR.Extensions.Autofac.DepdencyInjection.ConsoleApp/Program.cs
@@ -1,13 +1,16 @@
 ﻿using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Autofac;
+using Autofac.Extensions.DependencyInjection;
 using MediatR.Extensions.Autofac.DependencyInjection;
 using MediatR.Extensions.Autofac.DependencyInjection.Builder;
 using MediatR.Extensions.Autofac.DependencyInjection.Shared.Commands;
 using MediatR.Extensions.Autofac.DependencyInjection.Shared.Exceptions;
 using MediatR.Extensions.Autofac.DependencyInjection.Shared.Queries;
 using MediatR.Extensions.Autofac.DependencyInjection.Shared.Repositories;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace MediatR.Extensions.Autofac.DepdencyInjection.ConsoleApp;
 
@@ -28,6 +31,7 @@ public static class Program
 
         var configuration = MediatRConfigurationBuilder.Create(typeof(CustomerLoadQuery).Assembly).Build();
         builder.RegisterMediatR(configuration);
+        builder.Populate(Enumerable.Empty<ServiceDescriptor>());
 
         builder.RegisterType<CustomersRepository>()
             .As<ICustomersRepository>()

--- a/samples/MediatR.Extensions.Autofac.DependencyInjection.Shared/CommandHandler/CustomerAddCommandHandler.cs
+++ b/samples/MediatR.Extensions.Autofac.DependencyInjection.Shared/CommandHandler/CustomerAddCommandHandler.cs
@@ -8,7 +8,7 @@ using MediatR.Extensions.Autofac.DependencyInjection.Shared.Repositories;
 
 namespace MediatR.Extensions.Autofac.DependencyInjection.Shared.CommandHandler;
 
-public class CustomerAddCommandHandler : IRequestHandler<CustomerAddCommand>
+public class CustomerAddCommandHandler : IRequestHandler<CustomerAddCommand,Unit>
 {
     private readonly ICustomersRepository customersRepository;
     private readonly IMediator mediator;

--- a/samples/MediatR.Extensions.Autofac.DependencyInjection.Shared/Commands/CustomerAddCommand.cs
+++ b/samples/MediatR.Extensions.Autofac.DependencyInjection.Shared/Commands/CustomerAddCommand.cs
@@ -2,7 +2,7 @@
 
 namespace MediatR.Extensions.Autofac.DependencyInjection.Shared.Commands;
 
-public class CustomerAddCommand : IRequest
+public class CustomerAddCommand : IRequest<Unit>
 {
     public Guid Id { get; }
 

--- a/samples/MediatR.Extensions.Autofac.DependencyInjection.WebApi/Startup.cs
+++ b/samples/MediatR.Extensions.Autofac.DependencyInjection.WebApi/Startup.cs
@@ -36,7 +36,9 @@ public class Startup
             .As<ICustomersRepository>()
             .SingleInstance();
 
-        var configuration = MediatRConfigurationBuilder.Create(typeof(CustomerLoadQuery).Assembly).Build();
+        var configuration = MediatRConfigurationBuilder.Create(typeof(CustomerLoadQuery).Assembly)
+            .WithAllOpenGenericHandlerTypesRegistered()
+            .Build();
         
         builder.RegisterMediatR(configuration);
     }

--- a/samples/MediatR.Extensions.Autofac.DependencyInjection.WebApi/Startup.cs
+++ b/samples/MediatR.Extensions.Autofac.DependencyInjection.WebApi/Startup.cs
@@ -1,4 +1,6 @@
-﻿using Autofac;
+﻿using System.Linq;
+using Autofac;
+using Autofac.Extensions.DependencyInjection;
 using MediatR.Extensions.Autofac.DependencyInjection.Builder;
 using MediatR.Extensions.Autofac.DependencyInjection.Shared.Queries;
 using MediatR.Extensions.Autofac.DependencyInjection.Shared.Repositories;
@@ -39,5 +41,6 @@ public class Startup
         var configuration = MediatRConfigurationBuilder.Create(typeof(CustomerLoadQuery).Assembly).Build();
         
         builder.RegisterMediatR(configuration);
+        builder.Populate(Enumerable.Empty<ServiceDescriptor>());
     }
 }

--- a/src/MediatR.Extensions.Autofac.DependencyInjection/MediatR.Extensions.Autofac.DependencyInjection.csproj
+++ b/src/MediatR.Extensions.Autofac.DependencyInjection/MediatR.Extensions.Autofac.DependencyInjection.csproj
@@ -4,6 +4,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Autofac" Version="6.5.0" />
-    <PackageReference Include="MediatR" Version="11.1.0" />
+    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageReference Include="MediatR" Version="12.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
   </ItemGroup>
 </Project>

--- a/src/MediatR.Extensions.Autofac.DependencyInjection/MediatRModule.cs
+++ b/src/MediatR.Extensions.Autofac.DependencyInjection/MediatRModule.cs
@@ -1,6 +1,5 @@
 ﻿using System.Reflection;
 using Autofac;
-using Autofac.Features.Scanning;
 using MediatR.Extensions.Autofac.DependencyInjection.Extensions;
 using MediatR.Pipeline;
 using Module = Autofac.Module;
@@ -52,15 +51,6 @@ internal class MediatRModule : Module
         {
             this.RegisterGeneric(builder, customBehaviorType, typeof(IStreamPipelineBehavior<,>));
         }
-
-        builder
-            .Register<ServiceFactory>(outerContext =>
-            {
-                var innerContext = outerContext.Resolve<IComponentContext>();
-
-                return serviceType => innerContext.Resolve(serviceType);
-            })
-            .ApplyTargetScope(this.mediatRConfiguration.RegistrationScope);
     }
 
     private void RegisterGeneric(ContainerBuilder builder, Type implementationType, Type asType)

--- a/test/MediatR.Extensions.Autofac.DependencyInjection.Tests/Commands/VoidCommand.cs
+++ b/test/MediatR.Extensions.Autofac.DependencyInjection.Tests/Commands/VoidCommand.cs
@@ -1,5 +1,5 @@
 ﻿namespace MediatR.Extensions.Autofac.DependencyInjection.Tests.Commands;
 
-public class VoidCommand : IRequest
+public class VoidCommand : IRequest<Unit>
 {
 }

--- a/test/MediatR.Extensions.Autofac.DependencyInjection.Tests/Handler/CommandHandler.cs
+++ b/test/MediatR.Extensions.Autofac.DependencyInjection.Tests/Handler/CommandHandler.cs
@@ -4,7 +4,7 @@ using MediatR.Extensions.Autofac.DependencyInjection.Tests.Commands;
 
 namespace MediatR.Extensions.Autofac.DependencyInjection.Tests.Handler;
 
-public class CommandHandler : IRequestHandler<VoidCommand>
+public class CommandHandler : IRequestHandler<VoidCommand,Unit>
 {
     public Task<Unit> Handle(VoidCommand request, CancellationToken cancellationToken)
     {

--- a/test/MediatR.Extensions.Autofac.DependencyInjection.Tests/MediatR.Extensions.Autofac.DependencyInjection.Tests.csproj
+++ b/test/MediatR.Extensions.Autofac.DependencyInjection.Tests/MediatR.Extensions.Autofac.DependencyInjection.Tests.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.9.0" />
+    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">


### PR DESCRIPTION
## PLEASE REVIEW 
relates to #17 

Add support for MediatR v12

- Added `Unit` to `VoidCommand` return type to work with `IRequestPostProcessor` (which wants a TResponse?)
- Drop ServiceFactory registration, v12 mediatr now references IServiceProvider  from `Microsoft.Extensions.DependencyInjection.Abstractions` [See Migration Guide](https://github.com/jbogard/MediatR/wiki/Migration-Guide-11.x-to-12.0)
- Add `containerBuilder.Populate(Enumerable.Empty<ServiceDescriptor>());`  But I feel this is not ideal. And perhaps could be moved behind the `services.AddMediatR` function?  To avoid an end user having to remember to trigger this. (But perhaps there is a reason to customize when it gets called?)

I don't know enough about the triggering of the `containerBuilder.Populate` to understand the ideal configuration (or even if this is the correct resolution)

