### PR TITLE
Callback registration for handlers

### DIFF
--- a/samples/MediatR.Extensions.Autofac.DependencyInjection.WebApi/Startup.cs
+++ b/samples/MediatR.Extensions.Autofac.DependencyInjection.WebApi/Startup.cs
@@ -1,4 +1,5 @@
 ﻿using Autofac;
+using Autofac.Features.AttributeFilters;
 using MediatR.Extensions.Autofac.DependencyInjection.Builder;
 using MediatR.Extensions.Autofac.DependencyInjection.Shared.Queries;
 using MediatR.Extensions.Autofac.DependencyInjection.Shared.Repositories;
@@ -37,6 +38,7 @@ public class Startup
             .SingleInstance();
 
         var configuration = MediatRConfigurationBuilder.Create(typeof(CustomerLoadQuery).Assembly)
+            .WithOpenGenericHandlerTypeToRegisterCallback(x=>x.WithAttributeFiltering())
             .WithAllOpenGenericHandlerTypesRegistered()
             .Build();
         

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -13,8 +13,8 @@
     <PackageIcon>icon.png</PackageIcon>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>git://github.com/alsami/MediatR.Extensions.Autofac.DependencyInjection</RepositoryUrl>
-    <Version>11.0.0</Version>
-    <FileVersion>11.0.0.0</FileVersion>
+    <Version>11.1.0</Version>
+    <FileVersion>11.1.0.0</FileVersion>
     <EmbedAllSources>true</EmbedAllSources>
     <TreatWarningAsError>true</TreatWarningAsError>
     <Nullable>enable</Nullable>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -13,8 +13,8 @@
     <PackageIcon>icon.png</PackageIcon>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>git://github.com/alsami/MediatR.Extensions.Autofac.DependencyInjection</RepositoryUrl>
-    <Version>11.0.1</Version>
-    <FileVersion>11.0.1.0</FileVersion>
+    <Version>11.0.0</Version>
+    <FileVersion>11.0.0.0</FileVersion>
     <EmbedAllSources>true</EmbedAllSources>
     <TreatWarningAsError>true</TreatWarningAsError>
     <Nullable>enable</Nullable>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -13,8 +13,8 @@
     <PackageIcon>icon.png</PackageIcon>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>git://github.com/alsami/MediatR.Extensions.Autofac.DependencyInjection</RepositoryUrl>
-    <Version>11.0.0</Version>
-    <FileVersion>11.0.0.0</FileVersion>
+    <Version>11.0.1</Version>
+    <FileVersion>11.0.1.0</FileVersion>
     <EmbedAllSources>true</EmbedAllSources>
     <TreatWarningAsError>true</TreatWarningAsError>
     <Nullable>enable</Nullable>

--- a/src/MediatR.Extensions.Autofac.DependencyInjection/Builder/MediatRConfigurationBuilder.cs
+++ b/src/MediatR.Extensions.Autofac.DependencyInjection/Builder/MediatRConfigurationBuilder.cs
@@ -1,5 +1,7 @@
 using System.Reflection;
 using Autofac;
+using Autofac.Builder;
+using Autofac.Features.Scanning;
 using MediatR.NotificationPublishers;
 
 namespace MediatR.Extensions.Autofac.DependencyInjection.Builder;
@@ -15,6 +17,9 @@ public class MediatRConfigurationBuilder
     private readonly HashSet<Type> internalCustomStreamPipelineBehaviorTypes = new();
     private readonly HashSet<Type> internalOpenGenericHandlerTypesToRegister = new();
 
+    private Action<IRegistrationBuilder<object, ScanningActivatorData, DynamicRegistrationStyle>>
+        internalCustomRegistrationAction = _ => { };
+    
     private RegistrationScope registrationScope = RegistrationScope.Transient;
 
     private MediatRConfigurationBuilder(Assembly[] handlersFromAssembly)
@@ -152,10 +157,16 @@ public class MediatRConfigurationBuilder
             this.internalOpenGenericHandlerTypesToRegister.ToArray(),
             this.internalCustomPipelineBehaviorTypes.ToArray(),
             this.internalCustomStreamPipelineBehaviorTypes.ToArray(),
-            this.registrationScope);
+            this.registrationScope, this.internalCustomRegistrationAction);
     
     private void AddOpenGenericHandlerToRegister(Type openHandlerType)
     {
         this.internalOpenGenericHandlerTypesToRegister.Add(openHandlerType);
+    }
+
+    public MediatRConfigurationBuilder WithOpenGenericHandlerTypeToRegisterCallback(Action<IRegistrationBuilder<object, ScanningActivatorData, DynamicRegistrationStyle>> openGenericHandlerTypeToRegisterCallback)
+    {
+        this.internalCustomRegistrationAction = openGenericHandlerTypeToRegisterCallback;
+        return this;
     }
 }

--- a/src/MediatR.Extensions.Autofac.DependencyInjection/Builder/MediatRConfigurationBuilder.cs
+++ b/src/MediatR.Extensions.Autofac.DependencyInjection/Builder/MediatRConfigurationBuilder.cs
@@ -1,5 +1,7 @@
 using System.Reflection;
 using Autofac;
+using Autofac.Builder;
+using Autofac.Features.Scanning;
 using MediatR.NotificationPublishers;
 
 namespace MediatR.Extensions.Autofac.DependencyInjection.Builder;
@@ -14,6 +16,7 @@ public class MediatRConfigurationBuilder
     private readonly HashSet<Type> internalCustomPipelineBehaviorTypes = new();
     private readonly HashSet<Type> internalCustomStreamPipelineBehaviorTypes = new();
     private readonly HashSet<Type> internalOpenGenericHandlerTypesToRegister = new();
+    private readonly Dictionary<Type?, Action<IRegistrationBuilder<object, ScanningActivatorData, DynamicRegistrationStyle>>> internalCustomRegistrationAction = new();
 
     private RegistrationScope registrationScope = RegistrationScope.Transient;
 
@@ -146,16 +149,73 @@ public class MediatRConfigurationBuilder
     }
 
     public MediatRConfiguration Build() => new(
-            this.handlersFromAssembly,
-            this.mediatorType,
-            this.notificationPublisherType,
-            this.internalOpenGenericHandlerTypesToRegister.ToArray(),
-            this.internalCustomPipelineBehaviorTypes.ToArray(),
-            this.internalCustomStreamPipelineBehaviorTypes.ToArray(),
-            this.registrationScope);
+        this.handlersFromAssembly,
+        this.mediatorType,
+        this.notificationPublisherType,
+        this.internalOpenGenericHandlerTypesToRegister.ToArray(),
+        this.internalCustomPipelineBehaviorTypes.ToArray(),
+        this.internalCustomStreamPipelineBehaviorTypes.ToArray(),
+        this.registrationScope,
+        this.internalCustomRegistrationAction);
     
     private void AddOpenGenericHandlerToRegister(Type openHandlerType)
     {
         this.internalOpenGenericHandlerTypesToRegister.Add(openHandlerType);
+    }
+
+    /// <summary>
+    /// Register all open-generic handler-types with a callback. from <see cref="MediatR.Extensions.Autofac.DependencyInjection.KnownHandlerTypes"/>
+    /// </summary>
+    /// <param name="openGenericHandlerTypeToRegisterCallback">Delegate callback</param>
+    /// <returns>Self configured instance</returns>
+    public MediatRConfigurationBuilder WithOpenGenericHandlerTypeToRegisterCallback(Action<IRegistrationBuilder<object, ScanningActivatorData, DynamicRegistrationStyle>> openGenericHandlerTypeToRegisterCallback)
+    {
+        foreach (var type in internalOpenGenericHandlerTypesToRegister)
+        {
+            WithOpenGenericHandlerTypeToRegisterCallback(type, openGenericHandlerTypeToRegisterCallback);
+        }
+        return this;
+    }
+    
+    
+    /// <summary>
+    /// Register a callback for a specific open-generic handler-type.
+    /// </summary>
+    /// <param name="openGenericHandlerTypeToRegisterCallback"></param>
+    /// <typeparam name="TOpenGenericType">Type from <see cref="MediatR.Extensions.Autofac.DependencyInjection.KnownHandlerTypes"/></typeparam>
+    /// <returns></returns>
+    /// <exception cref="ArgumentException">If type that registered is out of scope of <see cref="MediatR.Extensions.Autofac.DependencyInjection.KnownHandlerTypes"/></exception>
+    internal MediatRConfigurationBuilder WithOpenGenericHandlerTypeToRegisterCallback<TOpenGenericType>(Action<IRegistrationBuilder<object, ScanningActivatorData, DynamicRegistrationStyle>> openGenericHandlerTypeToRegisterCallback)
+    {
+        var openGenericType = typeof(TOpenGenericType);
+        
+        return WithOpenGenericHandlerTypeToRegisterCallback(openGenericType, openGenericHandlerTypeToRegisterCallback);
+    }
+    
+    /// <summary>
+    /// Register a callback for a specific open-generic handler-type.
+    /// </summary>
+    /// <param name="openGenericType">Type of Handler like (IRequestHandler, INotificationHandler) etc.</param>
+    /// <param name="openGenericHandlerTypeToRegisterCallback">Callback</param>
+    /// <returns>Self configured instance</returns>
+    /// <exception cref="ArgumentException">If type that registered is out of scope of <see cref="MediatR.Extensions.Autofac.DependencyInjection.KnownHandlerTypes"/></exception>
+    internal MediatRConfigurationBuilder WithOpenGenericHandlerTypeToRegisterCallback(Type openGenericType, Action<IRegistrationBuilder<object, ScanningActivatorData, DynamicRegistrationStyle>> openGenericHandlerTypeToRegisterCallback)
+    {
+        if (!KnownHandlerTypes.AllTypes.Contains(openGenericType))
+        {
+            throw new ArgumentException(
+                $"Invalid open-generic handler-type {openGenericType.Name}",
+                nameof(openGenericType));
+        }
+
+        if (this.internalCustomRegistrationAction.ContainsKey(openGenericType))
+        {
+            this.internalCustomRegistrationAction[openGenericType] = openGenericHandlerTypeToRegisterCallback;
+        }
+        else
+        {
+            this.internalCustomRegistrationAction.Add(openGenericType, openGenericHandlerTypeToRegisterCallback);
+        }
+        return this;
     }
 }

--- a/src/MediatR.Extensions.Autofac.DependencyInjection/ContainerBuilderExtensions.cs
+++ b/src/MediatR.Extensions.Autofac.DependencyInjection/ContainerBuilderExtensions.cs
@@ -9,7 +9,6 @@ public static class ContainerBuilderExtensions
         MediatRConfiguration configuration)
     {
         builder.RegisterModule(new MediatRModule(configuration));
-
         return builder;
     }
 }

--- a/src/MediatR.Extensions.Autofac.DependencyInjection/MediatRConfiguration.cs
+++ b/src/MediatR.Extensions.Autofac.DependencyInjection/MediatRConfiguration.cs
@@ -1,9 +1,16 @@
 using System.Reflection;
+using Autofac.Builder;
+using Autofac.Features.Scanning;
 
 namespace MediatR.Extensions.Autofac.DependencyInjection;
 
 public class MediatRConfiguration
 {
+    internal IReadOnlyDictionary<Type?, Action<IRegistrationBuilder<object, ScanningActivatorData, DynamicRegistrationStyle>>>? InternalCustomRegistrationAction
+    {
+        get;
+    }
+    
     internal Assembly[] HandlersFromAssemblies { get; }
     
     internal Type MediatorType { get; }
@@ -18,15 +25,17 @@ public class MediatRConfiguration
     
     internal RegistrationScope RegistrationScope { get; }
     
-    internal MediatRConfiguration(
-        Assembly[] fromAssemblies,
+    internal MediatRConfiguration(Assembly[] fromAssemblies,
         Type mediatorType,
         Type notificationPublisherType,
         Type[] openGenericTypesToRegister,
         Type[]? customPipelineBehaviors = null,
         Type[]? customStreamPipelineBehaviors = null,
-        RegistrationScope registrationScope = RegistrationScope.Transient)
+        RegistrationScope registrationScope = RegistrationScope.Transient,
+        IReadOnlyDictionary<Type?, Action<IRegistrationBuilder<object, ScanningActivatorData, DynamicRegistrationStyle>>>?
+            internalCustomRegistrationAction = null)
     {
+        this.InternalCustomRegistrationAction = internalCustomRegistrationAction;
         this.HandlersFromAssemblies = fromAssemblies ?? throw new ArgumentNullException(nameof(fromAssemblies));
         this.MediatorType = mediatorType ?? throw new ArgumentNullException(nameof(mediatorType));
         this.NotificationPublisherType = notificationPublisherType ?? throw new ArgumentNullException(nameof(notificationPublisherType));
@@ -34,5 +43,13 @@ public class MediatRConfiguration
         this.CustomPipelineBehaviors = customPipelineBehaviors ?? Array.Empty<Type>();
         this.CustomStreamPipelineBehaviors = customStreamPipelineBehaviors ?? Array.Empty<Type>();
         this.RegistrationScope = registrationScope;
+    }
+    
+    internal void OpenGenericTypesToRegisterCallback(Type type, IRegistrationBuilder<object, ScanningActivatorData, DynamicRegistrationStyle> registeredType)
+    {
+        if (this.InternalCustomRegistrationAction?.TryGetValue(type, out var action) == true)
+        {
+            action.Invoke(registeredType);
+        }
     }
 }

--- a/src/MediatR.Extensions.Autofac.DependencyInjection/MediatRConfiguration.cs
+++ b/src/MediatR.Extensions.Autofac.DependencyInjection/MediatRConfiguration.cs
@@ -6,7 +6,7 @@ namespace MediatR.Extensions.Autofac.DependencyInjection;
 
 public class MediatRConfiguration
 {
-    internal Action<IRegistrationBuilder<object, ScanningActivatorData, DynamicRegistrationStyle>>? InternalCustomRegistrationAction
+    internal IReadOnlyDictionary<Type?, Action<IRegistrationBuilder<object, ScanningActivatorData, DynamicRegistrationStyle>>>? InternalCustomRegistrationAction
     {
         get;
     }
@@ -32,7 +32,7 @@ public class MediatRConfiguration
         Type[]? customPipelineBehaviors = null,
         Type[]? customStreamPipelineBehaviors = null,
         RegistrationScope registrationScope = RegistrationScope.Transient,
-        Action<IRegistrationBuilder<object, ScanningActivatorData, DynamicRegistrationStyle>>?
+        IReadOnlyDictionary<Type?, Action<IRegistrationBuilder<object, ScanningActivatorData, DynamicRegistrationStyle>>>?
             internalCustomRegistrationAction = null)
     {
         this.InternalCustomRegistrationAction = internalCustomRegistrationAction;
@@ -44,9 +44,12 @@ public class MediatRConfiguration
         this.CustomStreamPipelineBehaviors = customStreamPipelineBehaviors ?? Array.Empty<Type>();
         this.RegistrationScope = registrationScope;
     }
-
-    public void OpenGenericTypesToRegisterCallback(IRegistrationBuilder<object, ScanningActivatorData, DynamicRegistrationStyle> registeredType)
+    
+    internal void OpenGenericTypesToRegisterCallback(Type type, IRegistrationBuilder<object, ScanningActivatorData, DynamicRegistrationStyle> registeredType)
     {
-        this.InternalCustomRegistrationAction?.Invoke(registeredType);
+        if (this.InternalCustomRegistrationAction?.TryGetValue(type, out var action) == true)
+        {
+            action.Invoke(registeredType);
+        }
     }
 }

--- a/src/MediatR.Extensions.Autofac.DependencyInjection/MediatRConfiguration.cs
+++ b/src/MediatR.Extensions.Autofac.DependencyInjection/MediatRConfiguration.cs
@@ -1,9 +1,16 @@
 using System.Reflection;
+using Autofac.Builder;
+using Autofac.Features.Scanning;
 
 namespace MediatR.Extensions.Autofac.DependencyInjection;
 
 public class MediatRConfiguration
 {
+    internal Action<IRegistrationBuilder<object, ScanningActivatorData, DynamicRegistrationStyle>>? InternalCustomRegistrationAction
+    {
+        get;
+    }
+    
     internal Assembly[] HandlersFromAssemblies { get; }
     
     internal Type MediatorType { get; }
@@ -18,15 +25,17 @@ public class MediatRConfiguration
     
     internal RegistrationScope RegistrationScope { get; }
     
-    internal MediatRConfiguration(
-        Assembly[] fromAssemblies,
+    internal MediatRConfiguration(Assembly[] fromAssemblies,
         Type mediatorType,
         Type notificationPublisherType,
         Type[] openGenericTypesToRegister,
         Type[]? customPipelineBehaviors = null,
         Type[]? customStreamPipelineBehaviors = null,
-        RegistrationScope registrationScope = RegistrationScope.Transient)
+        RegistrationScope registrationScope = RegistrationScope.Transient,
+        Action<IRegistrationBuilder<object, ScanningActivatorData, DynamicRegistrationStyle>>?
+            internalCustomRegistrationAction = null)
     {
+        this.InternalCustomRegistrationAction = internalCustomRegistrationAction;
         this.HandlersFromAssemblies = fromAssemblies ?? throw new ArgumentNullException(nameof(fromAssemblies));
         this.MediatorType = mediatorType ?? throw new ArgumentNullException(nameof(mediatorType));
         this.NotificationPublisherType = notificationPublisherType ?? throw new ArgumentNullException(nameof(notificationPublisherType));
@@ -34,5 +43,10 @@ public class MediatRConfiguration
         this.CustomPipelineBehaviors = customPipelineBehaviors ?? Array.Empty<Type>();
         this.CustomStreamPipelineBehaviors = customStreamPipelineBehaviors ?? Array.Empty<Type>();
         this.RegistrationScope = registrationScope;
+    }
+
+    public void OpenGenericTypesToRegisterCallback(IRegistrationBuilder<object, ScanningActivatorData, DynamicRegistrationStyle> registeredType)
+    {
+        this.InternalCustomRegistrationAction?.Invoke(registeredType);
     }
 }

--- a/src/MediatR.Extensions.Autofac.DependencyInjection/MediatRModule.cs
+++ b/src/MediatR.Extensions.Autofac.DependencyInjection/MediatRModule.cs
@@ -1,5 +1,4 @@
-﻿using System.Runtime.CompilerServices;
-using Autofac;
+﻿using Autofac;
 using MediatR.Extensions.Autofac.DependencyInjection.Extensions;
 using MediatR.Pipeline;
 using Module = Autofac.Module;
@@ -44,9 +43,7 @@ internal class MediatRModule : Module
 
         foreach (var openHandlerType in this.mediatRConfiguration.OpenGenericTypesToRegister)
         {
-            builder.RegisterAssemblyTypes(this.mediatRConfiguration.HandlersFromAssemblies)
-                .AsClosedTypesOf(openHandlerType)
-                .ApplyTargetScope(this.mediatRConfiguration.RegistrationScope);
+            this.RegisterOpenType(builder, openHandlerType);
         }
 
         foreach (var builtInPipelineBehaviorType in this.builtInPipelineBehaviorTypes)
@@ -65,10 +62,20 @@ internal class MediatRModule : Module
         }
     }
 
+    private void RegisterOpenType(ContainerBuilder builder, Type openHandlerType)
+    {
+        var registeredType = builder.RegisterAssemblyTypes(this.mediatRConfiguration.HandlersFromAssemblies)
+            .AsClosedTypesOf(openHandlerType)
+            .ApplyTargetScope(this.mediatRConfiguration.RegistrationScope);
+        
+        this.mediatRConfiguration.OpenGenericTypesToRegisterCallback(openHandlerType, registeredType);
+    }
+
     private void RegisterGeneric(ContainerBuilder builder, Type implementationType, Type asType)
     {
         builder.RegisterGeneric(implementationType)
             .As(asType)
             .ApplyTargetScope(this.mediatRConfiguration.RegistrationScope);
     }
+    
 }

--- a/src/MediatR.Extensions.Autofac.DependencyInjection/MediatRModule.cs
+++ b/src/MediatR.Extensions.Autofac.DependencyInjection/MediatRModule.cs
@@ -1,5 +1,4 @@
-﻿using System.Runtime.CompilerServices;
-using Autofac;
+﻿using Autofac;
 using MediatR.Extensions.Autofac.DependencyInjection.Extensions;
 using MediatR.Pipeline;
 using Module = Autofac.Module;
@@ -44,9 +43,10 @@ internal class MediatRModule : Module
 
         foreach (var openHandlerType in this.mediatRConfiguration.OpenGenericTypesToRegister)
         {
-            builder.RegisterAssemblyTypes(this.mediatRConfiguration.HandlersFromAssemblies)
+            var registeredType = builder.RegisterAssemblyTypes(this.mediatRConfiguration.HandlersFromAssemblies)
                 .AsClosedTypesOf(openHandlerType)
                 .ApplyTargetScope(this.mediatRConfiguration.RegistrationScope);
+            this.mediatRConfiguration.OpenGenericTypesToRegisterCallback(registeredType);
         }
 
         foreach (var builtInPipelineBehaviorType in this.builtInPipelineBehaviorTypes)

--- a/src/MediatR.Extensions.Autofac.DependencyInjection/MediatRModule.cs
+++ b/src/MediatR.Extensions.Autofac.DependencyInjection/MediatRModule.cs
@@ -43,10 +43,7 @@ internal class MediatRModule : Module
 
         foreach (var openHandlerType in this.mediatRConfiguration.OpenGenericTypesToRegister)
         {
-            var registeredType = builder.RegisterAssemblyTypes(this.mediatRConfiguration.HandlersFromAssemblies)
-                .AsClosedTypesOf(openHandlerType)
-                .ApplyTargetScope(this.mediatRConfiguration.RegistrationScope);
-            this.mediatRConfiguration.OpenGenericTypesToRegisterCallback(registeredType);
+            this.RegisterOpenType(builder, openHandlerType);
         }
 
         foreach (var builtInPipelineBehaviorType in this.builtInPipelineBehaviorTypes)
@@ -65,10 +62,20 @@ internal class MediatRModule : Module
         }
     }
 
+    private void RegisterOpenType(ContainerBuilder builder, Type openHandlerType)
+    {
+        var registeredType = builder.RegisterAssemblyTypes(this.mediatRConfiguration.HandlersFromAssemblies)
+            .AsClosedTypesOf(openHandlerType)
+            .ApplyTargetScope(this.mediatRConfiguration.RegistrationScope);
+        
+        this.mediatRConfiguration.OpenGenericTypesToRegisterCallback(openHandlerType, registeredType);
+    }
+
     private void RegisterGeneric(ContainerBuilder builder, Type implementationType, Type asType)
     {
         builder.RegisterGeneric(implementationType)
             .As(asType)
             .ApplyTargetScope(this.mediatRConfiguration.RegistrationScope);
     }
+    
 }

--- a/test/MediatR.Extensions.Autofac.DependencyInjection.Tests/Commands/ConvertEstDateTimeCommand.cs
+++ b/test/MediatR.Extensions.Autofac.DependencyInjection.Tests/Commands/ConvertEstDateTimeCommand.cs
@@ -1,0 +1,24 @@
+using System;
+using MediatR.Extensions.Autofac.DependencyInjection.Tests.Services;
+
+namespace MediatR.Extensions.Autofac.DependencyInjection.Tests.Commands;
+
+public class ConvertEstDateTimeCommand : IRequest<DateTime>
+{
+    public DateTime DateTime { get; }
+
+    public ConvertEstDateTimeCommand(DateTime dateTime)
+    {
+        this.DateTime = dateTime;
+    }
+}
+
+public class ConvertUtcDateTimeCommand : IRequest<DateTime>
+{
+    public DateTime DateTime { get; }
+
+    public ConvertUtcDateTimeCommand(DateTime dateTime)
+    {
+        this.DateTime = dateTime;
+    }
+}

--- a/test/MediatR.Extensions.Autofac.DependencyInjection.Tests/Handler/DateTimeConverterServiceCommandHandler.cs
+++ b/test/MediatR.Extensions.Autofac.DependencyInjection.Tests/Handler/DateTimeConverterServiceCommandHandler.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Autofac.Features.AttributeFilters;
+using MediatR.Extensions.Autofac.DependencyInjection.Tests.Commands;
+using MediatR.Extensions.Autofac.DependencyInjection.Tests.Services;
+
+namespace MediatR.Extensions.Autofac.DependencyInjection.Tests.Handler;
+
+public class ConvertEstDateTimeCommandHandler : IRequestHandler<ConvertEstDateTimeCommand, DateTime>
+{
+    private readonly IDateTimeConverterService dateTimeConverterService;
+
+    public ConvertEstDateTimeCommandHandler([KeyFilter("EST")] IDateTimeConverterService dateTimeConverterService)
+    {
+        this.dateTimeConverterService = dateTimeConverterService;
+    }
+    
+    public Task<DateTime> Handle(ConvertEstDateTimeCommand request, CancellationToken cancellationToken)
+    {
+        return Task.FromResult(this.dateTimeConverterService.ConvertDateTime(request.DateTime));
+    }
+}
+
+public class ConvertUtcDateTimeCommandHandler : IRequestHandler<ConvertUtcDateTimeCommand, DateTime>
+{
+    private readonly IDateTimeConverterService dateTimeConverterService;
+
+    public ConvertUtcDateTimeCommandHandler([KeyFilter("UTC")] IDateTimeConverterService dateTimeConverterService)
+    {
+        this.dateTimeConverterService = dateTimeConverterService;
+    }
+    
+    public Task<DateTime> Handle(ConvertUtcDateTimeCommand request, CancellationToken cancellationToken)
+    {
+        return Task.FromResult(this.dateTimeConverterService.ConvertDateTime(request.DateTime));
+    }
+}

--- a/test/MediatR.Extensions.Autofac.DependencyInjection.Tests/Services/EstDateTimeConverterService.cs
+++ b/test/MediatR.Extensions.Autofac.DependencyInjection.Tests/Services/EstDateTimeConverterService.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace MediatR.Extensions.Autofac.DependencyInjection.Tests.Services;
+
+
+public class EstDateTimeConverterService : IDateTimeConverterService
+{
+    public DateTime ConvertDateTime(DateTime sourceDateTime)
+    {
+        if (sourceDateTime.Kind == DateTimeKind.Unspecified)
+        {
+            throw new ArgumentException("The kind of the source date time is unspecified");
+        }
+
+        TimeZoneInfo estZone;
+        
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            estZone = TimeZoneInfo.FindSystemTimeZoneById("Eastern Standard Time");
+        }
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            estZone = TimeZoneInfo.FindSystemTimeZoneById("America/New_York");
+        }
+        else
+        {
+            throw new PlatformNotSupportedException("The current platform is not supported");
+        }
+
+        DateTime targetDateTime;
+
+        if (sourceDateTime.Kind == DateTimeKind.Utc)
+        {
+            targetDateTime = TimeZoneInfo.ConvertTimeFromUtc(sourceDateTime, estZone);
+        }
+        else
+        {
+            var utcDateTime = sourceDateTime.ToUniversalTime();
+            targetDateTime = TimeZoneInfo.ConvertTimeFromUtc(utcDateTime, estZone);
+        }
+
+        return targetDateTime;
+    }
+}

--- a/test/MediatR.Extensions.Autofac.DependencyInjection.Tests/Services/IDateTimeConverterService.cs
+++ b/test/MediatR.Extensions.Autofac.DependencyInjection.Tests/Services/IDateTimeConverterService.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace MediatR.Extensions.Autofac.DependencyInjection.Tests.Services;
+
+public interface IDateTimeConverterService
+{
+    DateTime ConvertDateTime(DateTime sourceDateTime);
+}

--- a/test/MediatR.Extensions.Autofac.DependencyInjection.Tests/Services/UtcDateTimeConverterService.cs
+++ b/test/MediatR.Extensions.Autofac.DependencyInjection.Tests/Services/UtcDateTimeConverterService.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace MediatR.Extensions.Autofac.DependencyInjection.Tests.Services;
+
+public class UtcDateTimeConverterService : IDateTimeConverterService
+{
+    public DateTime ConvertDateTime(DateTime sourceDateTime)
+    {
+        return sourceDateTime.ToUniversalTime();
+    }
+}


### PR DESCRIPTION
I want to have option to register handlers with [KeyFilter](https://autofac.readthedocs.io/en/latest/advanced/keyed-services.html) attribute. so I can register it like this:
```
builder.RegisterMediatR(
            MediatRConfigurationBuilder.Create(assembly)
                .WithAllOpenGenericHandlerTypesRegistered()
                .WithOpenGenericHandlerTypeToRegisterCallback(x => x.WithAttributeFiltering())
                .WithRegistrationScope(RegistrationScope.Scoped)
                .Build());
```
I know it can be done better 😞